### PR TITLE
Backport: suporte a CNPJ alfanumérico via pt-br-validator (1.x)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,16 @@
         "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0",
         "illuminate/http": "^8.0|^9.0|^10.0|^11.0|^12.0",
         "illuminate/console": "^8.0|^9.0|^10.0|^11.0|^12.0",
-        "illuminate/database": "^8.0|^9.0|^10.0|^11.0|^12.0"
+        "illuminate/database": "^8.0|^9.0|^10.0|^11.0|^12.0",
+        "laravellegends/pt-br-validator": "^12.2"
     },
     "extra": {
         "laravel": {
             "providers": [
                 "HeroLaraToolkit\\Providers\\HeroLaraToolkitServiceProvider"
+            ],
+            "dont-discover": [
+                "laravellegends/pt-br-validator"
             ]
         }
     }

--- a/src/Helpers/ValidatorHelper.php
+++ b/src/Helpers/ValidatorHelper.php
@@ -2,6 +2,8 @@
 
 namespace HeroLaraToolkit\Helpers;
 
+use LaravelLegends\PtBrValidator\Rules\Cnpj;
+
 class ValidatorHelper
 {
     public static function cpf(string $cpf): bool
@@ -33,41 +35,7 @@ class ValidatorHelper
 
     public static function cnpj(string $cnpj): bool
     {
-        $cnpj = preg_replace('/[^0-9]/', '', $cnpj);
-
-        if (strlen($cnpj) != 14) {
-            return false;
-        }
-
-        $sum = 0;
-        $length = strlen($cnpj) - 2;
-
-        for ($t = 12; $t >= 1; $t--) {
-            $sum += $cnpj[$length - $t] * $t;
-        }
-
-        $mod = $sum % 11;
-        $digit = $mod < 2 ? 0 : 11 - $mod;
-
-        if ($cnpj[$length] != $digit) {
-            return false;
-        }
-
-        $sum = 0;
-        $length++;
-
-        for ($t = 13; $t >= 1; $t--) {
-            $sum += $cnpj[$length - $t] * $t;
-        }
-
-        $mod = $sum % 11;
-        $digit = $mod < 2 ? 0 : 11 - $mod;
-
-        if ($cnpj[$length] != $digit) {
-            return false;
-        }
-
-        return true;
+        return (new Cnpj())->passes('cnpj', $cnpj);
     }
 
     public static function phone(string $telefone): bool


### PR DESCRIPTION
## Resumo

Backport do PR #6 (main/2.x) para a linha `1.x`, mantida para consumidores que ainda não migraram para a v2.0.0 (breaking change do `make:service`).

- Adiciona `laravellegends/pt-br-validator` (^12.2) como dependência.
- `ValidatorHelper::cnpj()` delega para a rule `Cnpj` do pt-br-validator — algoritmo oficial da Receita Federal, com suporte a CNPJ alfanumérico (IN RFB 2.229/2024).
- `extra.laravel.dont-discover` suprime o autodiscovery duplicado do `ValidatorProvider` do pt-br-validator nos consumidores.

## Classificação: patch, não breaking

A assinatura pública não muda (`ValidatorHelper::cnpj(string): bool`, mesma rule `cnpj`). O algoritmo antigo usava pesos não-oficiais e já validava CNPJs numéricos incorretamente em ambos os sentidos (aceitava inválidos, rejeitava válidos) — delegar corrige isso além de adicionar o alfanumérico. Tratado como patch/minor nesta linha, consistente com o pedido original da task de não quebrar a API pública que hero-admin, xavier-service e chip-service já chamam hoje.

## Validação

Mesmos casos de teste do PR #6 (numérico e alfanumérico válido/inválido, incluindo o exemplo oficial do manual Serpro/RFB `12ABC34501DE` → DVs `3`,`5`), conferidos manualmente via script (esta linha não tem suíte Pest/Testbench).

## Task

Runrun.it: https://runrun.it/pt-BR/tasks/22968 (epic https://runrun.it/pt-BR/tasks/16246, feature https://runrun.it/pt-BR/tasks/22965)

Relacionado: #6 (mesmo patch em main/2.x)