### PR TITLE
Corrige versão do pt-br-validator para ^12.2 (regressão pós-merge do #6)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "illuminate/database": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
         "illuminate/routing": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
         "illuminate/filesystem": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
-        "laravellegends/pt-br-validator": "^13.0"
+        "laravellegends/pt-br-validator": "^12.2"
     },
     "require-dev": {
         "orchestra/testbench": "^9.0|^10.0|^11.0",


### PR DESCRIPTION
## Resumo

O PR #6 foi mergeado sem o commit `80308e4`, que corrigia a faixa de versão de `laravellegends/pt-br-validator` de `^13.0` para `^12.2`.